### PR TITLE
Add ReserveCalifornia support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,17 @@ Content-Type: application/json
 The `campground_id` corresponds to the ID from Recreation.gov. The `check_time` is the time of day (24h format) the watcher should run.
 
 When availability is found, a message is printed to the console. This can be extended to send an email or other notification.
+
+### ReserveCalifornia Endpoints
+
+Two additional endpoints allow checking campsite information for California
+State Parks using ReserveCalifornia.
+
+```bash
+GET /ca_availability?park_id=<park>&facility_id=<facility>&start_date=YYYY-MM-DD
+GET /ca_update_time?park_id=<park>&facility_id=<facility>
+```
+
+`/ca_availability` returns the raw availability JSON from the ReserveCalifornia
+API. `/ca_update_time` scrapes the park page to find the timestamp of the next
+scheduled availability update, if available.

--- a/app.py
+++ b/app.py
@@ -5,6 +5,7 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 import requests
 import datetime
+from reserve_ca import fetch_availability as fetch_ca_availability, fetch_update_time as fetch_ca_update_time
 
 # Database setup
 engine = create_engine('sqlite:///watchers.db')
@@ -84,6 +85,27 @@ def search_campgrounds():
     lon = request.args.get('lon')
     results = fetch_campgrounds(query, lat, lon)
     return jsonify(results)
+
+
+@app.route('/ca_availability')
+def ca_availability():
+    park_id = request.args.get('park_id')
+    facility_id = request.args.get('facility_id')
+    start_date = request.args.get('start_date')
+    if not park_id or not facility_id or not start_date:
+        return jsonify({'error': 'park_id, facility_id and start_date required'}), 400
+    data = fetch_ca_availability(park_id, facility_id, start_date)
+    return jsonify(data)
+
+
+@app.route('/ca_update_time')
+def ca_update_time():
+    park_id = request.args.get('park_id')
+    facility_id = request.args.get('facility_id')
+    if not park_id or not facility_id:
+        return jsonify({'error': 'park_id and facility_id required'}), 400
+    update_dt = fetch_ca_update_time(park_id, facility_id)
+    return jsonify({'next_update_time': update_dt.isoformat() if update_dt else None})
 
 
 @app.route('/watchers', methods=['POST'])

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Flask==2.3.2
 requests==2.31.0
 APScheduler==3.9.1
 SQLAlchemy==2.0.19
+beautifulsoup4==4.12.3

--- a/reserve_ca.py
+++ b/reserve_ca.py
@@ -1,0 +1,58 @@
+import requests
+from bs4 import BeautifulSoup
+import re
+from datetime import datetime
+
+PARK_PAGE_URL = "https://www.reservecalifornia.com/Web/#!park/{park_id}/{facility_id}"
+AVAILABILITY_API = "https://calirdr.usedirect.com/RDR/rdr/availability/park"
+
+
+def fetch_availability(park_id: str, facility_id: str, start_date: str):
+    """Fetch availability data for a specific park and facility.
+
+    Parameters
+    ----------
+    park_id: str
+        Numeric ID of the park.
+    facility_id: str
+        Numeric ID of the facility/loop within the park.
+    start_date: str
+        Date string in YYYY-MM-DD format.
+
+    Returns
+    -------
+    dict
+        Parsed JSON availability response.
+    """
+    params = {
+        "parkId": park_id,
+        "facilityId": facility_id,
+        "startDate": start_date,
+    }
+    resp = requests.get(AVAILABILITY_API, params=params)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def fetch_update_time(park_id: str, facility_id: str):
+    """Parse the park page to determine the next availability update time.
+
+    The ReserveCalifornia park page embeds a JSON blob containing the next time
+    new availability will be released. This function extracts that timestamp and
+    returns it as a ``datetime``.
+    """
+    url = PARK_PAGE_URL.format(park_id=park_id, facility_id=facility_id)
+    resp = requests.get(url)
+    resp.raise_for_status()
+    soup = BeautifulSoup(resp.text, "html.parser")
+    script_tags = soup.find_all("script")
+    for tag in script_tags:
+        if not tag.string:
+            continue
+        m = re.search(r'"nextAvailabilityUpdate"\s*:\s*"([^"]+)"', tag.string)
+        if m:
+            try:
+                return datetime.fromisoformat(m.group(1))
+            except ValueError:
+                pass
+    return None


### PR DESCRIPTION
## Summary
- add `reserve_ca.py` for ReserveCalifornia availability and update parsing
- expose `/ca_availability` and `/ca_update_time` Flask endpoints
- document new endpoints in README
- add `beautifulsoup4` to requirements

## Testing
- `python -m py_compile app.py reserve_ca.py`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed 403)*
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685f790f52d88321b0be95563b80e3b0