### PR TITLE
Implement booking difficulty ranking utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,14 +45,27 @@ When availability is found, a message is printed to the console. This can be ext
 
 ### ReserveCalifornia Endpoints
 
-Two additional endpoints allow checking campsite information for California
-State Parks using ReserveCalifornia.
+Two additional endpoints allow checking campsite information for California State Parks using ReserveCalifornia.
 
 ```bash
 GET /ca_availability?park_id=<park>&facility_id=<facility>&start_date=YYYY-MM-DD
 GET /ca_update_time?park_id=<park>&facility_id=<facility>
 ```
 
-`/ca_availability` returns the raw availability JSON from the ReserveCalifornia
-API. `/ca_update_time` scrapes the park page to find the timestamp of the next
-scheduled availability update, if available.
+`/ca_availability` returns the raw availability JSON from the ReserveCalifornia API. `/ca_update_time` scrapes the park page to find the timestamp of the next scheduled availability update, if available.
+
+### Ranking Booking Difficulty
+
+The `ranking.py` module provides helper functions to estimate how difficult it is to book a campground and to order individual sites by scarcity. Example usage:
+
+```python
+from ranking import difficulty_score, rank_sites_for_campground
+
+score = difficulty_score("232450")
+print("Difficulty score:", score)
+
+sites = rank_sites_for_campground("232450")
+print("Least available sites:", sites[:3])
+```
+
+Higher difficulty scores indicate fewer available dates across all sites.

--- a/ranking.py
+++ b/ranking.py
@@ -1,0 +1,67 @@
+# coding: utf-8
+"""Utility functions for ranking campsite demand and booking difficulty."""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Dict, List, Tuple
+
+import requests
+
+AVAILABILITY_API = "https://www.recreation.gov/api/camps/availability/campground/{campground_id}/month"
+
+
+def _fetch_availability(campground_id: str, month_str: str) -> Dict:
+    """Return raw availability JSON for a campground and month."""
+    start_date = f"{month_str}-01T00:00:00.000Z"
+    url = AVAILABILITY_API.format(campground_id=campground_id)
+    resp = requests.get(url, params={"start_date": start_date})
+    resp.raise_for_status()
+    return resp.json()
+
+
+def difficulty_score(campground_id: str, month: str | None = None) -> float:
+    """Estimate how hard it is to book a campsite at a campground.
+
+    The score is 1.0 when no sites are available at all and decreases as
+    availability increases. 0.0 means every site is available every day.
+    """
+    if not month:
+        month = date.today().strftime("%Y-%m")
+    data = _fetch_availability(campground_id, month)
+    total_days = 0
+    available_days = 0
+    for site in data.get("campsites", {}).values():
+        availabilities = site.get("availabilities", {})
+        total_days += len(availabilities)
+        available_days += sum(1 for val in availabilities.values() if val == "Available")
+    if total_days == 0:
+        return 1.0
+    ratio = available_days / total_days
+    return 1.0 - ratio
+
+
+def rank_sites_for_campground(campground_id: str, month: str | None = None) -> List[Tuple[str, float]]:
+    """Return site IDs ranked by scarcity (lower availability first)."""
+    if not month:
+        month = date.today().strftime("%Y-%m")
+    data = _fetch_availability(campground_id, month)
+    site_scores: List[Tuple[str, float]] = []
+    for site_id, site in data.get("campsites", {}).items():
+        availabilities = site.get("availabilities", {})
+        total = len(availabilities)
+        available = sum(1 for val in availabilities.values() if val == "Available")
+        rate = available / total if total else 0.0
+        site_scores.append((site_id, rate))
+    site_scores.sort(key=lambda t: t[1])  # least available first
+    return site_scores
+
+
+def rank_campgrounds(campground_ids: List[str], month: str | None = None) -> List[Tuple[str, float]]:
+    """Rank campgrounds by difficulty score in descending order."""
+    scores = []
+    for cid in campground_ids:
+        scores.append((cid, difficulty_score(cid, month)))
+    scores.sort(key=lambda t: t[1], reverse=True)
+    return scores
+


### PR DESCRIPTION
## Summary
- add `ranking.py` helper with functions to score and rank campground difficulty
- document difficulty ranking helpers in README

## Testing
- `python -m py_compile app.py reserve_ca.py ranking.py`

------
https://chatgpt.com/codex/tasks/task_e_685f7ace40a083218e130f6c23e99fde