### PR TITLE
Refactor and add config

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,18 @@ This is a simple Flask web application that allows users to search for campsites
 
 ## Setup
 
+Set environment variables if needed:
+- `SEARCH_API`
+- `AVAILABILITY_API`
+- `DATABASE_URI`
+
+
 1. Install dependencies (use a virtual environment recommended):
    ```bash
    pip install -r requirements.txt
    ```
 
-2. Run the application:
+2. The SQLite database will be created on first run. Run the application:
    ```bash
    python app.py
    ```
@@ -80,3 +86,9 @@ python tui.py
 
 The interface lets you filter for weekend-only dates and highlights locations
 that are in high demand.
+
+### Running Tests
+
+```bash
+pytest
+```

--- a/app.py
+++ b/app.py
@@ -1,140 +1,102 @@
-from flask import Flask, request, jsonify
-from apscheduler.schedulers.background import BackgroundScheduler
-from sqlalchemy import create_engine, Column, Integer, String, Time
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
-import requests
-import datetime
-from reserve_ca import fetch_availability as fetch_ca_availability, fetch_update_time as fetch_ca_update_time
+"""Flask application entry point."""
 
-# Database setup
-engine = create_engine('sqlite:///watchers.db')
-Base = declarative_base()
-SessionLocal = sessionmaker(bind=engine)
+from __future__ import annotations
 
-class Watcher(Base):
-    __tablename__ = 'watchers'
-    id = Column(Integer, primary_key=True)
-    campground_id = Column(String, nullable=False)
-    site_type = Column(String, nullable=True)
-    check_time = Column(String, nullable=False)  # HH:MM
-    email = Column(String, nullable=True)
+import logging
+from logging.config import dictConfig
 
-Base.metadata.create_all(engine)
+from flask.typing import ResponseReturnValue
+from flask import Flask, jsonify, request
 
-app = Flask(__name__)
-scheduler = BackgroundScheduler()
-
-SEARCH_API = "https://www.recreation.gov/api/facilities"
-AVAILABILITY_API = "https://www.recreation.gov/api/camps/availability/campground/{campground_id}/month"  # need start_date
+from campwatcher import api
+from campwatcher.models import SessionLocal, Watcher
+from campwatcher.schemas import WatcherCreate
+from campwatcher.scheduling import schedule_watcher, scheduler
+from campwatcher.config import config
+from reserve_ca import (
+    fetch_availability as fetch_ca_availability,
+    fetch_update_time as fetch_ca_update_time,
+)
 
 
-def fetch_campgrounds(query, lat=None, lon=None):
-    params = {"query": query}
-    if lat and lon:
-        params.update({"latitude": lat, "longitude": lon})
-    resp = requests.get(SEARCH_API, params=params)
-    resp.raise_for_status()
-    data = resp.json()
-    return data.get("RECDATA", [])
+def create_app() -> Flask:
+    """Create and configure the Flask app."""
+    app = Flask(__name__)
 
+    dictConfig(
+        {
+            "version": 1,
+            "formatters": {
+                "default": {"format": "%(asctime)s %(levelname)s %(name)s: %(message)s"}
+            },
+            "handlers": {
+                "console": {"class": "logging.StreamHandler", "formatter": "default"}
+            },
+            "root": {"level": "INFO", "handlers": ["console"]},
+        }
+    )
 
-def check_availability(campground_id, month_str, site_type=None):
-    start_date = f"{month_str}-01T00:00:00.000Z"
-    url = AVAILABILITY_API.format(campground_id=campground_id)
-    resp = requests.get(url, params={"start_date": start_date})
-    resp.raise_for_status()
-    data = resp.json()
-    available = []
-    for site_id, months in data.get("campsites", {}).items():
-        for day, info in months.get("availabilities", {}).items():
-            if info == "Available":
-                if not site_type or months.get("campsite_type") == site_type:
-                    available.append({"site_id": site_id, "date": day})
-    return available
+    @app.route("/search")
+    def search_campgrounds() -> ResponseReturnValue:
+        query = request.args.get("query")
+        lat = request.args.get("lat")
+        lon = request.args.get("lon")
+        results = api.fetch_campgrounds(query, lat, lon)
+        return jsonify(results)
 
+    @app.route("/ca_availability")
+    def ca_availability() -> ResponseReturnValue:
+        park_id = request.args.get("park_id")
+        facility_id = request.args.get("facility_id")
+        start_date = request.args.get("start_date")
+        if not park_id or not facility_id or not start_date:
+            return (
+                jsonify({"error": "park_id, facility_id and start_date required"}),
+                400,
+            )
+        data = fetch_ca_availability(park_id, facility_id, start_date)
+        return jsonify(data)
 
-def schedule_watcher(watcher_id, time_str):
-    hour, minute = map(int, time_str.split(":"))
-    scheduler.add_job(func=run_watcher, trigger='cron', args=[watcher_id], id=str(watcher_id), hour=hour, minute=minute)
+    @app.route("/ca_update_time")
+    def ca_update_time() -> ResponseReturnValue:
+        park_id = request.args.get("park_id")
+        facility_id = request.args.get("facility_id")
+        if not park_id or not facility_id:
+            return jsonify({"error": "park_id and facility_id required"}), 400
+        update_dt = fetch_ca_update_time(park_id, facility_id)
+        return jsonify(
+            {"next_update_time": update_dt.isoformat() if update_dt else None}
+        )
 
+    @app.route("/watchers", methods=["POST"])
+    def add_watcher() -> ResponseReturnValue:
+        model = WatcherCreate.model_validate(request.json)
+        session = SessionLocal()
+        watcher = Watcher(
+            campground_id=model.campground_id,
+            site_type=model.site_type,
+            check_time=model.check_time,
+            email=model.email,
+        )
+        session.add(watcher)
+        session.commit()
+        schedule_watcher(watcher.id, model.check_time)
+        session.close()
+        return jsonify({"id": watcher.id})
 
-def run_watcher(watcher_id):
-    session = SessionLocal()
-    watcher = session.query(Watcher).filter(Watcher.id == watcher_id).first()
-    if not watcher:
-        return
-    today = datetime.date.today()
-    month_str = today.strftime("%Y-%m")
-    try:
-        avail = check_availability(watcher.campground_id, month_str, watcher.site_type)
-        if avail:
-            print(f"Availability found for watcher {watcher.id}: {avail}")
-        else:
-            print(f"No availability for watcher {watcher.id}")
-    except Exception as e:
-        print(f"Error checking watcher {watcher.id}: {e}")
-    finally:
+    @app.before_first_request
+    def start_scheduler() -> None:
+        session = SessionLocal()
+        watchers = session.query(Watcher).all()
+        for w in watchers:
+            schedule_watcher(w.id, w.check_time)
+        scheduler.start()
         session.close()
 
-
-@app.route('/search')
-def search_campgrounds():
-    query = request.args.get('query')
-    lat = request.args.get('lat')
-    lon = request.args.get('lon')
-    results = fetch_campgrounds(query, lat, lon)
-    return jsonify(results)
+    return app
 
 
-@app.route('/ca_availability')
-def ca_availability():
-    park_id = request.args.get('park_id')
-    facility_id = request.args.get('facility_id')
-    start_date = request.args.get('start_date')
-    if not park_id or not facility_id or not start_date:
-        return jsonify({'error': 'park_id, facility_id and start_date required'}), 400
-    data = fetch_ca_availability(park_id, facility_id, start_date)
-    return jsonify(data)
+app = create_app()
 
-
-@app.route('/ca_update_time')
-def ca_update_time():
-    park_id = request.args.get('park_id')
-    facility_id = request.args.get('facility_id')
-    if not park_id or not facility_id:
-        return jsonify({'error': 'park_id and facility_id required'}), 400
-    update_dt = fetch_ca_update_time(park_id, facility_id)
-    return jsonify({'next_update_time': update_dt.isoformat() if update_dt else None})
-
-
-@app.route('/watchers', methods=['POST'])
-def add_watcher():
-    data = request.json
-    campground_id = data.get('campground_id')
-    site_type = data.get('site_type')
-    check_time = data.get('check_time')  # HH:MM
-    email = data.get('email')
-    if not campground_id or not check_time:
-        return jsonify({'error': 'campground_id and check_time required'}), 400
-    session = SessionLocal()
-    watcher = Watcher(campground_id=campground_id, site_type=site_type, check_time=check_time, email=email)
-    session.add(watcher)
-    session.commit()
-    schedule_watcher(watcher.id, check_time)
-    session.close()
-    return jsonify({'id': watcher.id})
-
-
-@app.before_first_request
-def start_scheduler():
-    session = SessionLocal()
-    watchers = session.query(Watcher).all()
-    for w in watchers:
-        schedule_watcher(w.id, w.check_time)
-    scheduler.start()
-    session.close()
-
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     app.run(debug=True)

--- a/campwatcher/__init__.py
+++ b/campwatcher/__init__.py
@@ -1,0 +1,5 @@
+"""Campwatcher package."""
+
+from . import api, config, models, scheduling
+
+__all__ = ["api", "config", "models", "scheduling"]

--- a/campwatcher/api.py
+++ b/campwatcher/api.py
@@ -1,0 +1,38 @@
+"""Helper functions for Recreation.gov endpoints."""
+
+from typing import Any, Dict, List, Optional
+
+import requests
+
+from .config import config
+
+
+def fetch_campgrounds(
+    query: str, lat: str | None = None, lon: str | None = None
+) -> List[Dict[str, Any]]:
+    """Search for campgrounds using the Recreation.gov API."""
+    params = {"query": query}
+    if lat and lon:
+        params.update({"latitude": lat, "longitude": lon})
+    resp = requests.get(config.search_api, params=params)
+    resp.raise_for_status()
+    data = resp.json()
+    return data.get("RECDATA", [])
+
+
+def check_availability(
+    campground_id: str, month_str: str, site_type: str | None = None
+) -> List[Dict[str, str]]:
+    """Return available site IDs for a campground/month."""
+    start_date = f"{month_str}-01T00:00:00.000Z"
+    url = config.availability_api.format(campground_id=campground_id)
+    resp = requests.get(url, params={"start_date": start_date})
+    resp.raise_for_status()
+    data = resp.json()
+    available: List[Dict[str, str]] = []
+    for site_id, months in data.get("campsites", {}).items():
+        for day, info in months.get("availabilities", {}).items():
+            if info == "Available":
+                if not site_type or months.get("campsite_type") == site_type:
+                    available.append({"site_id": site_id, "date": day})
+    return available

--- a/campwatcher/config.py
+++ b/campwatcher/config.py
@@ -1,0 +1,19 @@
+import os
+from dataclasses import dataclass
+
+
+@dataclass
+class Config:
+    """Application configuration."""
+
+    search_api: str = os.getenv(
+        "SEARCH_API", "https://www.recreation.gov/api/facilities"
+    )
+    availability_api: str = os.getenv(
+        "AVAILABILITY_API",
+        "https://www.recreation.gov/api/camps/availability/campground/{campground_id}/month",
+    )
+    db_uri: str = os.getenv("DATABASE_URI", "sqlite:///watchers.db")
+
+
+config = Config()

--- a/campwatcher/models.py
+++ b/campwatcher/models.py
@@ -1,0 +1,24 @@
+from sqlalchemy import Column, Integer, String, create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+
+from .config import config
+
+engine = create_engine(config.db_uri)
+Base = declarative_base()
+SessionLocal = sessionmaker(bind=engine)
+
+
+class Watcher(Base):
+    """Database model for stored watchers."""
+
+    __tablename__ = "watchers"
+
+    id = Column(Integer, primary_key=True)
+    campground_id = Column(String, nullable=False)
+    site_type = Column(String, nullable=True)
+    check_time = Column(String, nullable=False)  # HH:MM
+    email = Column(String, nullable=True)
+
+
+Base.metadata.create_all(engine)

--- a/campwatcher/scheduling.py
+++ b/campwatcher/scheduling.py
@@ -1,0 +1,49 @@
+"""Job scheduling utilities."""
+
+from __future__ import annotations
+
+import datetime
+import logging
+from typing import List
+
+from apscheduler.schedulers.background import BackgroundScheduler
+
+from .api import check_availability
+from .models import SessionLocal, Watcher
+
+scheduler = BackgroundScheduler()
+logger = logging.getLogger(__name__)
+
+
+def schedule_watcher(watcher_id: int, time_str: str) -> None:
+    """Schedule a watcher by ID at HH:MM."""
+    hour, minute = map(int, time_str.split(":"))
+    scheduler.add_job(
+        func=run_watcher,
+        trigger="cron",
+        args=[watcher_id],
+        id=str(watcher_id),
+        hour=hour,
+        minute=minute,
+    )
+
+
+def run_watcher(watcher_id: int) -> None:
+    """Check availability for a stored watcher and log results."""
+    session = SessionLocal()
+    watcher = session.query(Watcher).filter(Watcher.id == watcher_id).first()
+    if not watcher:
+        session.close()
+        return
+    today = datetime.date.today()
+    month_str = today.strftime("%Y-%m")
+    try:
+        avail = check_availability(watcher.campground_id, month_str, watcher.site_type)
+        if avail:
+            logger.info("Availability found for watcher %s: %s", watcher.id, avail)
+        else:
+            logger.info("No availability for watcher %s", watcher.id)
+    except Exception as exc:  # noqa: BLE001
+        logger.error("Error checking watcher %s: %s", watcher.id, exc)
+    finally:
+        session.close()

--- a/campwatcher/schemas.py
+++ b/campwatcher/schemas.py
@@ -1,0 +1,19 @@
+"""Request and response models."""
+
+from pydantic import BaseModel, Field, validator
+
+
+class WatcherCreate(BaseModel):
+    """Schema for creating a watcher."""
+
+    campground_id: str = Field(..., description="Recreation.gov campground ID")
+    site_type: str | None = Field(None, description="Campsite type")
+    check_time: str = Field(..., regex=r"^\d{2}:\d{2}$", description="Time in HH:MM")
+    email: str | None = Field(None, description="Notification email")
+
+    @validator("check_time")
+    def _validate_time(cls, v: str) -> str:  # noqa: D401,N802
+        hour, minute = map(int, v.split(":"))
+        if hour not in range(24) or minute not in range(60):
+            raise ValueError("check_time must be valid HH:MM")
+        return v

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ requests==2.31.0
 APScheduler==3.9.1
 SQLAlchemy==2.0.19
 beautifulsoup4==4.12.3
+pydantic==2.7.1
+pytest==7.4.4

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -1,0 +1,12 @@
+import sys, os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from campwatcher.config import config
+from ranking import difficulty_score
+
+
+def test_difficulty_score_returns_float(mocker):
+    mocker.patch("ranking._fetch_availability", return_value={"campsites": {}})
+    result = difficulty_score("100")
+    assert isinstance(result, float)

--- a/tui.py
+++ b/tui.py
@@ -6,12 +6,14 @@ from typing import List, Tuple
 # Simple mapping of ZIP codes to coordinates for demo purposes
 ZIP_COORDS = {
     "94102": (37.7793, -122.4193),  # San Francisco
-    "10001": (40.7506, -73.9971),   # New York
-    "30301": (33.7525, -84.3915),   # Atlanta
+    "10001": (40.7506, -73.9971),  # New York
+    "30301": (33.7525, -84.3915),  # Atlanta
 }
 
 SEARCH_API = "https://www.recreation.gov/api/facilities"
-AVAILABILITY_API = "https://www.recreation.gov/api/camps/availability/campground/{campground_id}/month"
+AVAILABILITY_API = (
+    "https://www.recreation.gov/api/camps/availability/campground/{campground_id}/month"
+)
 
 
 def fetch_campgrounds(lat: float, lon: float) -> List[dict]:


### PR DESCRIPTION
## Summary
- restructure app as a package
- add config module with environment variable support
- replace print statements with logging
- use Pydantic model for watcher creation
- document environment variables and tests
- add basic pytest

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_685f7c9f433c8321b3c023a6854ddc47