### PR TITLE
Add Streamlit UI and GitHub Pages site

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,23 @@ that are in high demand.
 Browse to `http://localhost:5000/` after starting the server for a basic form
 to search campgrounds with the new filters.
 
+### Streamlit Interface
+
+A lightweight Streamlit app provides an alternative UI. Launch it with:
+
+```bash
+streamlit run streamlit_app.py
+```
+
+It queries Recreation.gov directly and displays difficulty scores alongside
+search results.
+
+### GitHub Pages
+
+A static search page lives in the `docs/` directory. When this repository is
+served on GitHub Pages it offers a simple client-side experience using the
+public Recreation.gov API.
+
 ### Running Tests
 
 ```bash

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Campsite Finder</title>
+<style>
+body { font-family: Arial, sans-serif; padding: 2rem; }
+.container { max-width: 800px; margin: auto; }
+input[type=text] { width: 100%; padding: 0.5rem; margin: 0.5rem 0; }
+button { padding: 0.5rem 1rem; }
+table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
+th, td { border: 1px solid #ddd; padding: 0.5rem; text-align: left; }
+</style>
+</head>
+<body>
+<div class="container">
+<h1>Campsite Finder</h1>
+<input id="query" type="text" placeholder="Search">
+<button onclick="search()">Search</button>
+<table id="results"></table>
+</div>
+<script>
+function search() {
+  const q = document.getElementById('query').value;
+  if (!q) return;
+  const url = 'https://www.recreation.gov/api/facilities?query=' + encodeURIComponent(q);
+  fetch(url)
+    .then(r => r.json())
+    .then(data => {
+      const rows = (data.RECDATA || []).map(c => `<tr><td>${c.FacilityName}</td><td>${c.FacilityID}</td></tr>`).join('');
+      document.getElementById('results').innerHTML = '<tr><th>Name</th><th>ID</th></tr>' + rows;
+    })
+    .catch(err => console.error(err));
+}
+</script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ SQLAlchemy==2.0.19
 beautifulsoup4==4.12.3
 pydantic==2.7.1
 pytest==7.4.4
+streamlit==1.32.2

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,43 @@
+import streamlit as st
+from campwatcher import api
+from ranking import difficulty_score
+from campground_data import CAMPGROUND_ATTRIBUTES
+
+st.set_page_config(page_title="Campsite Finder", page_icon="\U0001F3D5")
+st.title("Campsite Finder")
+
+query = st.text_input("Search")
+col1, col2 = st.columns(2)
+with col1:
+    latitude = st.text_input("Latitude", placeholder="Optional")
+with col2:
+    longitude = st.text_input("Longitude", placeholder="Optional")
+
+filters = st.sidebar
+filters.header("Filters")
+tent_only = filters.checkbox("Tent only")
+no_rv = filters.checkbox("No RV")
+
+if st.button("Search"):
+    if not query:
+        st.warning("Enter a search term.")
+    else:
+        results = api.fetch_campgrounds(query, latitude or None, longitude or None)
+        display = []
+        for camp in results:
+            cid = str(camp.get("FacilityID"))
+            attrs = CAMPGROUND_ATTRIBUTES.get(cid, {})
+            if tent_only and not attrs.get("tent_only"):
+                continue
+            if no_rv and not attrs.get("no_rv"):
+                continue
+            score = difficulty_score(cid)
+            display.append({
+                "Name": camp.get("FacilityName"),
+                "ID": cid,
+                "Difficulty": f"{score:.2f}",
+            })
+        if display:
+            st.dataframe(display)
+        else:
+            st.info("No results found.")

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -6,7 +6,10 @@ from campwatcher.config import config
 from ranking import difficulty_score
 
 
-def test_difficulty_score_returns_float(mocker):
-    mocker.patch("ranking._fetch_availability", return_value={"campsites": {}})
+def test_difficulty_score_returns_float(monkeypatch):
+    monkeypatch.setattr(
+        "ranking._fetch_availability",
+        lambda *args, **kwargs: {"campsites": {}},
+    )
     result = difficulty_score("100")
     assert isinstance(result, float)


### PR DESCRIPTION
## Summary
- add Streamlit interface for searching campgrounds
- provide static HTML page under `docs/` for GitHub Pages
- document Streamlit and GitHub Pages usage in the README
- update dependencies and tests

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685f851247b88321bf6cc82d6db5be64